### PR TITLE
Fix a.pypi.python.org

### DIFF
--- a/pypi_mirrors.py
+++ b/pypi_mirrors.py
@@ -59,7 +59,7 @@ def parse_date(date_str):
     return datetime.datetime.strptime(date_str, date_fmt)
 
 
-def humanize_date_difference(now, otherdate=None, offset=None):
+def humanize_date_difference(now, otherdate=None, offset=None, sign="ago"):
     """ This function prints the difference between two python datetime objects
     in a more human readable form
 
@@ -69,8 +69,10 @@ def humanize_date_difference(now, otherdate=None, offset=None):
     https://gist.github.com/207624
     """
     if otherdate:
-        dt = now - otherdate
+        dt = abs(now - otherdate)
         delta_d, offset = dt.days, dt.seconds
+        if now < otherdate:
+            sign = "ahead"
     elif offset:
         delta_d, offset = divmod(offset, 60 * 60 * 24)
     else:
@@ -79,28 +81,31 @@ def humanize_date_difference(now, otherdate=None, offset=None):
     delta_h, delta_m = divmod(offset, 60)
 
     if delta_d:
-        fmt = "{d:d} days, {h:d} hours, {m:d} minutes ago"
+        fmt = "{d:d} days, {h:d} hours, {m:d} minutes {ago}"
     elif delta_h:
-        fmt = "{h:d} hours, {m:d} minutes ago"
+        fmt = "{h:d} hours, {m:d} minutes {ago}"
     elif delta_m:
-        fmt = "{m:d} minutes, {s:d} seconds ago"
+        fmt = "{m:d} minutes, {s:d} seconds {ago}"
     else:
-        fmt = "{s:d} seconds ago"
-    return fmt.format(d=delta_d, h=delta_h, m=delta_m, s=delta_s)
+        fmt = "{s:d} seconds {ago}"
+    return fmt.format(d=delta_d, h=delta_h, m=delta_m, s=delta_s, ago=sign)
 
 
-def gather_data(now, mirror_url=MIRROR_URL, master_url=MASTER_URL):
+def gather_data(mirror_url=MIRROR_URL, master_url=MASTER_URL):
     """ get the data we need put in dict """
-    # a.pypi.python.org is the master server
-    ml = 'a.pypi.python.org'
-    m_url = master_url.format(ml)
-    res = ping_mirror(m_url)
-    ping_results = [(ml, res)]
+    ping_results = []
     for ml in get_mirrors():
         m_url = mirror_url.format(ml)
         res = ping_mirror(m_url)
         ping_results.append((ml, res))
 
+    # a.pypi.python.org is the master server
+    ml = 'a.pypi.python.org'
+    m_url = master_url.format(ml)
+    res = ping_mirror(m_url)
+    ping_results.insert(0, (ml, res))
+
+    now = datetime.datetime.utcnow()
     results = []
     for ml, res in ping_results:
         if res:
@@ -115,12 +120,11 @@ def gather_data(now, mirror_url=MIRROR_URL, master_url=MASTER_URL):
                 'last_update': "Unavailable",
                 'how_old':  "Unavailable"}
             )
-    return results
+    return now, results
 
 
 def generate_page(format='html'):
-    now = datetime.datetime.utcnow()
-    data = gather_data(now)
+    now, data = gather_data()
     body = "<table border='1' width='50%'>"
     body += "<tr><th>Mirror</th><th>Last update</th><th>Age</th></tr>"
     row = "<tr><td>{mirror}</td><td>{last_update}</td><td>{how_old}</td></tr>"


### PR DESCRIPTION
According to the PEP 381, this "a" is the master server.
I double checked it with "host a.pypi.python.org" and "host pypi.python.org".

Then I've found this interesting post by MvL with a script which checks "/daytime" to verify the clock of this master server.
http://mail.python.org/pipermail/catalog-sig/2012-March/004339.html

I've ajusted the script accordingly. The delta should be 0s under normal conditions, if the master website is up.
