### PR TITLE
add pypi mirror provided by douban.com

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,6 +4,7 @@ import json
 # Add non-official mirrors here
 UNOFFICIAL_MIRRORS = [
      'pypi.crate.io',
+     ‘pypi.douban.com',
 ]
 
 EMAIL_OVERRIDE = None # None or "blah@example.com"


### PR DESCRIPTION
pypi.douban.com is provided by douban.com to speed up chinese developers.  I'd like to see it's status on http://www.pypi-mirrors.org/ :smiley:
