### PR TITLE
Add mirror usage instructions.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -90,7 +90,19 @@
             </tbody>
         </table>
     </div>
-    <div class="span9"></div>
+
+    <div class="span4">
+        <h3>Using a mirror</h3>
+        <p><strong>Single Usage:</strong> <br/>
+          <pre>pip -i http://&lt;mirror&gt;/simple install &lt;package&gt;</pre>
+        <p><strong>Global settings:</strong> </br>
+          Add <code>~/.pip/pip.conf</code> that includes:
+          <pre>
+[global]
+index-url = http://&lt;mirror&gt;/simple</pre>
+        </p>
+    </div>
+    <div class="span5"></div>
     </div>
     <div class="row-fluid">
     <div class="span9">


### PR DESCRIPTION
Hi, being in China www.pypi-mirrors.org has been very useful, thanks for that! Standard mirror is very (very!) slow here. I would have saved some time if the page showed how to use the mirrors. So here is a commit with mirror usage instructions, feel free to modify it as you will.

Screenshot:
![image](https://f.cloud.github.com/assets/919180/1995161/394b3ad2-84ff-11e3-92d7-0b68b4ba83c0.png)
