### PR TITLE
Adds mirror.picosecond.org/pypi to mirror list.

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ MIRRORS = [
      ('http', 'pypi.hustunique.com'),
      ('http', 'pypi.gocept.com'),
      ('http', 'pypi.tuna.tsinghua.edu.cn'),
+     ('http', 'mirror.picosecond.org/pypi'),
 ]
 
 EMAIL_OVERRIDE = None # None or "blah@example.com"


### PR DESCRIPTION
I've recently started mirroring pypi, and would appreciate my mirror being added to the list.

Thanks.
